### PR TITLE
Allow options to be passed to the respond callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module.exports = {
       };
 
     // You can pass a custom callback to `res.respond`, which will be called after the responders have been run
-    return res.respond(data, function (err, req, res, data) {
+    return res.respond(data, function (err, req, res, data, options) {
       return res.view('user/goodbye', data);
     });
   },

--- a/responses/respond.js
+++ b/responses/respond.js
@@ -40,7 +40,7 @@ module.exports = function respond (data, options, done) {
    * @type {Function}
    */
   done = (util.isFunction(data) && data) || (util.isFunction(options) && options) || (util.isFunction(done) && done) ||
-    function respondCallback (err, req, res, data) {
+    function respondCallback (err, req, res, data, options) {
       if (err) { sails.log.error(err); }
 
       /**
@@ -72,6 +72,6 @@ module.exports = function respond (data, options, done) {
      * Ensure that the data object is available to the final callback
      */
     function (err) {
-      return done(err, req, res, data);
+      return done(err, req, res, data, options);
     });
 };


### PR DESCRIPTION
This makes the `options` object available in the custom callbacks methods for respond